### PR TITLE
clarify licensing status and purpose of GitHub presence

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # Typora
 
-[Typora](http://typora.io) (beta) is a minimal markdown editor, providing new ways for reading and writing markdown.
+[Typora](http://typora.io) is a minimal markdown editor, providing new ways for reading and writing markdown. It is currently in beta.
+
+Typora is commercial software (not open source), but is free during beta. [Typora on GitHub](https://github.com/typora) supports collaboration between its developer (@abnerlee) and its *user community*, providing a place to transparently report issues, collect feedback and discuss future direction. It also provides open source resources for user customization of themes.
 
 # What this Repository is for
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [Typora](http://typora.io) is a minimal markdown editor, providing new ways for reading and writing markdown. It is currently in beta.
 
-Typora is commercial software (not open source), but is free during beta. [Typora on GitHub](https://github.com/typora) supports collaboration between its developer (@abnerlee) and its *user community*, providing a place to transparently report issues, collect feedback and discuss future direction. It also provides open source resources for user customization of themes.
+Typora is commercial software (not open source), but is free during beta. [Typora on GitHub](https://github.com/typora) supports collaboration between its developer, [Abner Lee](http://abnerlee.github.io), and its *user community*, providing a place to transparently report issues, collect feedback and discuss future direction. It also provides open source resources for user customization of themes.
 
 # What this Repository is for
 


### PR DESCRIPTION
As can be seen in the comments under Issue #16, there is a lot of confusion and misunderstanding about whether Typora will ever be open source, and whether it will always be free. 

I think the licensing plans for Typora should be stated clearly in this README. In addition, Issue #16 should be closed and marked as won't fix. It has 56 thumbs up and 33 hearts. Keeping it open confuses and misleads people, giving them the false expectation that you are considering open sourcing it.

