### PR TITLE
Remove references to beta status from the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 > Note: Our offical website is <https://typora.io> and <https://typoraio.cn>. All other websites without those two domain suffix is phishing site.
 
-[Typora](http://typora.io) is a minimal markdown editor, providing new ways for reading and writing markdown. It is currently in beta.
+[Typora](http://typora.io) is a minimal markdown editor, providing new ways for reading and writing markdown.
 
-Typora is commercial software (not open source), but is free during beta. [Typora on GitHub](https://github.com/typora) supports collaboration between its developer, and its *user community*, providing a place to transparently report issues, collect feedback and discuss future direction. It also provides open source resources for user customization of themes.
+Typora is commercial software (not open source). [Typora on GitHub](https://github.com/typora) supports collaboration between its developer, and its *user community*, providing a place to transparently report issues, collect feedback and discuss future direction. It also provides open source resources for user customization of themes.
 
 # The Typora Issues Repo
 


### PR DESCRIPTION
Typora has been out of beta status [since November 2021](https://support.typora.io/What's-New-1.0/), but there are still outdated references in the README to it being in beta and free, which could cause confusion.